### PR TITLE
Allow cells to be formatted as numbers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/tealeg/xlsx v1.0.5
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,14 @@
 github.com/aymerick/raymond v2.0.2+incompatible h1:VEp3GpgdAnv9B2GFyTvqgcKvY+mfKMjPOA3SbKLtnU0=
 github.com/aymerick/raymond v2.0.2+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/tealeg/xlsx v1.0.5 h1:+f8oFmvY8Gw1iUXzPk+kz+4GpbDZPK1FhPiQRd+ypgE=
 github.com/tealeg/xlsx v1.0.5/go.mod h1:btRS8dz54TDnvKNosuAqxrM1QgN1udgk9O34bDCnORM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/xlst.go
+++ b/xlst.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/aymerick/raymond"
@@ -16,6 +17,7 @@ var (
 	rgx         = regexp.MustCompile(`\{\{\s*(\w+)\.\w+\s*\}\}`)
 	rangeRgx    = regexp.MustCompile(`\{\{\s*range\s+(\w+)\s*\}\}`)
 	rangeEndRgx = regexp.MustCompile(`\{\{\s*end\s*\}\}`)
+	numRgx      = regexp.MustCompile(`^#[0-9]+(\.[0-9]+)?`)
 )
 
 // Xlst Represents template struct
@@ -207,7 +209,15 @@ func renderCell(cell *xlsx.Cell, ctx interface{}) error {
 	if err != nil {
 		return err
 	}
-	cell.Value = out
+	if numRgx.MatchString(out) {
+		f, err := strconv.ParseFloat(strings.TrimPrefix(out, "#"), 64)
+		if err != nil {
+			return err
+		}
+		cell.SetFloat(f)
+	} else {
+		cell.Value = out
+	}
 	return nil
 }
 

--- a/xlst.go
+++ b/xlst.go
@@ -17,7 +17,7 @@ var (
 	rgx         = regexp.MustCompile(`\{\{\s*(\w+)\.\w+\s*\}\}`)
 	rangeRgx    = regexp.MustCompile(`\{\{\s*range\s+(\w+)\s*\}\}`)
 	rangeEndRgx = regexp.MustCompile(`\{\{\s*end\s*\}\}`)
-	numRgx      = regexp.MustCompile(`^#[0-9]+(\.[0-9]+)?`)
+	numRgx      = regexp.MustCompile(`^#-?[0-9]+(\.[0-9]+)?`)
 )
 
 // Xlst Represents template struct


### PR DESCRIPTION
Allows cells to be number formatted by prefixing the value with a # followed by a valid numeric string. In the template, the number formatting can be applied to an individual cell to have the looped rows each have that formatting when formatted as a number.

This allows users viewing the Excel file to select ranges to see a sum, create formulas that do arithmetic on cells, and much more.

#### Example 

##### Template

| Name | Pay |
| ------ | -------|
| {{range users}}  |  | 
| {{name }} | #{{pay}} |
| {{end}} | |

##### Data

```json
[
  {
    "name": "Alice",
    "pay": 27
  },
  {
    "name": "Bob",
    "pay": 31.5
  }
]
```

##### Reults

| Name | Pay |
| ------ | -------|
| Alice | $27.00 | 
| Bob | $31.50 | 

It's untested if this works with timestamps, but if not. I'd submit `@` as a prefix to signify it.