### PR TITLE
Added handling for []interface{} in getRangeCtx function

### DIFF
--- a/xlst.go
+++ b/xlst.go
@@ -247,6 +247,16 @@ func getRangeCtx(ctx map[string]interface{}, prop string) []map[string]interface
 		return nil
 	}
 
+	if in, ok := val.([]interface{}); ok {
+		var propCtx = make([]map[string]interface{}, 0, len(in))
+		for _, prop := range in {
+			if ctx, ok := prop.(map[string]interface{}); ok {
+				propCtx = append(propCtx, ctx)
+			}
+		}
+		return propCtx
+	}
+
 	if propCtx, ok := val.([]map[string]interface{}); ok {
 		return propCtx
 	}


### PR DESCRIPTION
More information can be found [`here`](https://stackoverflow.com/questions/73380914/cast-nested-interface-to-mapstringinterface/73699455?noredirect=1#comment130182777_73699455) in stackoverflow question